### PR TITLE
Solves pb of claims disappearing: gives claims a unique Id

### DIFF
--- a/src/mappings/handleClaimSuccess.ts
+++ b/src/mappings/handleClaimSuccess.ts
@@ -34,7 +34,7 @@ export default function handleClaimSuccess(event: ClaimSuccess): void {
 
 	let externalUserId = decodedTuple[1].toString()
 	let claimantAsset = decodedTuple[3].toString()
-	let claimId = generateClaimId(externalUserId, claimantAsset)
+	let claimId = generateClaimId(externalUserId, bountyAddress)
 	let claim = new Claim(claimId)
 	let tier = BigInt.fromString('0')
 
@@ -54,10 +54,10 @@ export default function handleClaimSuccess(event: ClaimSuccess): void {
 	claim.save()
 }
 
-function generateClaimId(externalUserId: string, claimantAsset: string): string {
+function generateClaimId(externalUserId: string, bountyAddress: string): string {
 	let claimantIdArray: Array<ethereum.Value> = [
 		ethereum.Value.fromString(externalUserId),
-		ethereum.Value.fromString(claimantAsset)
+		ethereum.Value.fromString(bountyAddress.toString())
 	]
 
 	let tuple = changetype<ethereum.Tuple>(claimantIdArray)


### PR DESCRIPTION
The problem was that the ClaimId was not unique after the PR (i.e. claimantAsset) became the same for every bounty - hence the previous claims disappeared when the same ID was given to a new claim

On the prod subgraph we can see that many of the winners claimed several bounties - and probably the previous claims started disappearing  from the moment we implemented the single PR...?