### PR TITLE
replacing externalUserId with Tier to create claimId since sometimes …

### DIFF
--- a/src/mappings/handleClaimSuccess.ts
+++ b/src/mappings/handleClaimSuccess.ts
@@ -34,13 +34,16 @@ export default function handleClaimSuccess(event: ClaimSuccess): void {
 
 	let externalUserId = decodedTuple[1].toString()
 	let claimantAsset = decodedTuple[3].toString()
-	let claimId = generateClaimId(externalUserId, bountyAddress)
-	let claim = new Claim(claimId)
+
 	let tier = BigInt.fromString('0')
 
 	if (bountyType == Constants.TIERED_PERCENTAGE || bountyType == Constants.TIERED_FIXED) {
 		tier = decodedTuple[4].toBigInt()
 	}
+
+	
+	let claimId = generateClaimId(bountyAddress, tier)
+	let claim = new Claim(claimId)
 
 	claim.bountyType = bountyType
 	claim.bounty = bountyAddress
@@ -54,10 +57,10 @@ export default function handleClaimSuccess(event: ClaimSuccess): void {
 	claim.save()
 }
 
-function generateClaimId(externalUserId: string, bountyAddress: string): string {
+function generateClaimId(bountyAddress: string, tier: BigInt): string {
 	let claimantIdArray: Array<ethereum.Value> = [
-		ethereum.Value.fromString(externalUserId),
-		ethereum.Value.fromString(bountyAddress.toString())
+		ethereum.Value.fromString(bountyAddress.toString()),
+		ethereum.Value.fromString(tier.toString())
 	]
 
 	let tuple = changetype<ethereum.Tuple>(claimantIdArray)


### PR DESCRIPTION
Reason - just saw on prod that sometimes the same github user claims twice on one bounty
(example bounty: https://openq.dev/contract/I_kwDOI-Vpys5fSJcU/0x6dd47b0d23c67cfcf0221e0cb2a15a511f8bc4bd)

Note: I removed externalUserId altogether from the claimID since there will always only be one tier per bounty